### PR TITLE
ensures that the string is at least 40 characters long

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -152,7 +152,7 @@ class Client:
         return None
     
     async def mint_morkie_nft(self, contract_address: str) -> Optional[bool]:
-        formatted = self.wallet_address.lstrip('0x').lower()
+        formatted = self.wallet_address.lstrip('0x').zfill(40).lower()
         tx_params = {
             'to': contract_address,
             'from': self.wallet_address,


### PR DESCRIPTION
zfill(40): This method ensures that the string is at least 40 characters long, padding with leading zeros if necessary. This is important for Ethereum addresses, which should always be 40 hexadecimal characters long after removing the '0x' prefix.